### PR TITLE
Remove jumpbox inbound network rule for port 22

### DIFF
--- a/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/configuration/networking/nsg.tfvars
+++ b/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/configuration/networking/nsg.tfvars
@@ -365,4 +365,10 @@ network_security_group_definition = {
       },
     ]
   }
+
+  jumpbox = {
+    nsg = [
+
+    ]
+  }
 }

--- a/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/configuration/networking/nsg.tfvars
+++ b/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/configuration/networking/nsg.tfvars
@@ -6,7 +6,7 @@ network_security_group_definition = {
   # This entry is applied to all subnets with no NSG defined
   azure_kubernetes_cluster_nsg = {
     nsg = [
-      
+
     ]
   }
   azure_bastion_nsg = {
@@ -365,21 +365,4 @@ network_security_group_definition = {
       },
     ]
   }
-
-  jumpbox = {
-    nsg = [
-      {
-        name                       = "ssh-inbound-22",
-        priority                   = "200"
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "tcp"
-        source_port_range          = "*"
-        destination_port_range     = "22"
-        source_address_prefix      = "*"
-        destination_address_prefix = "VirtualNetwork"
-      },
-    ]
-  }
-
 }


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

The network security group for the jumpbox allowed ssh traffic on the jumpbox subnet. This is not required since we do not create a jumpbox VM. Allowing the port also shows an warning in the portal about leaving the port open. There is another task, to address this if we do end up needing a jumpbox. https://github.com/retaildevcrews/ngsa/issues/673

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

- Follow terraform instructions to create an environment
- In the Azure portal. the navigate to the vnet hub resource group
- Click on the jumpbox network security group
- The network rules should no longer allow incoming traffic on port 22

![Annotation 2021-04-08 072001](https://user-images.githubusercontent.com/3047161/114025598-e73d2000-983a-11eb-83b9-510f6f44d5eb.png)

Closes https://github.com/retaildevcrews/ngsa/issues/674
