### PR TITLE
Updated terraform scripts to add firewall application rules to allow github container registry

### DIFF
--- a/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/configuration/networking/firewall_application_rule_collection_definition.tfvars
+++ b/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/configuration/networking/firewall_application_rule_collection_definition.tfvars
@@ -110,6 +110,25 @@ azurerm_firewall_application_rule_collection_definition = {
           }
         }
       },
+      ghcr = {
+        name = "ghcr"
+        # source_addresses = [
+        # "*",
+        # ]
+        source_ip_groups_keys = [
+        "aks_ip_group1"
+        ]
+        target_fqdns = [
+        "ghcr.io", # GitHub Packages
+        "pkg-containers-az.githubusercontent.com" # specifically added for loderunner image
+        ]
+        protocol = {
+          http = {
+            port = "443"
+            type = "Https"
+          }
+        }
+      },
       mcr = {
         name = "mcr"
         # source_addresses = [

--- a/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/loderunner/README.md
+++ b/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/loderunner/README.md
@@ -13,21 +13,6 @@ The following instructions will deploy LodeRunner on your CAF Secure Baseline in
 
 Instructions on how to deploy the NGSA Memory app can be found [here](../ngsa/README.md).
 
-### Whitelist the GitHub Packages URL (pkg-containers-az.githubusercontent.com) in the infrastructure firewall
-
-This is needed as otherwise the deployment of LodeRunner will fail.
-To do this, head over to your Azure Portal and find the vNet-Hub resource group created by Infrastructure Provisioning, e.g. vnet-hub-re1, then locate the egress firewall resource.
-
-Go to packages application rule collection by navigating to:
-
-[Egress Firewall] > [Setting] > [Rules(Classic)] > [Application rule collection] > [Packages]
-
-Add the a new Target FQDN
-
-| **name**  | **Source type** |      **Source**     | **Protocol:Port** | **Target FQDNs** |
-|-----------|-----------------|---------------------|-------------------|------------------|
-| github-pkgs      | IP Group        |same as Docker entry |     Https:443     |     pkg-containers-az.githubusercontent.com      |
-
 ## Deployment
 
 Ensure that you had navigated to this folder. Then, run the following command to deploy the LodeRunner app.

--- a/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/ngsa/README.md
+++ b/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/ngsa/README.md
@@ -88,28 +88,6 @@ helm repo update
 
 ```
 
-## Add GitHub Packages (ghcr.io) to firewall white list
-
-```bash
-From Azure portal locate and navigate the vNet-Hub resource group created by Infrastructure Provisioning, e.g. vnet-hub-re1, then locate the egress firewall resource.
-
-Go to packages application rule collection by navigating to:
-
-[Egress Firwall] > [Setting] > [Rules(Classic)] > [Application rule collection] > [Packages]
-
-Add the a new Target FQDN
-```
-
-| **name**  | **Source type** |      **Source**     | **Protocol:Port** | **Target FQDNs** |
-|-----------|-----------------|---------------------|-------------------|------------------|
-| ghcr      | IP Group        |same as Docker entry |     Https:443     |     ghcr.io      |
-
-```bash
-# Note: This step will be automated on a later Infrastructure Provisioning release.
-# if you skip this step, the pod will not be able to download the image.
-```
-
-
 ## Deploy NGSA with Helm
 ```bash
 The NGSA application has been packed into a Helm chart for deployment into the cluster. The following instructions will walk you through the manual process of deployment of the helm chart and is recommended for development and testing.


### PR DESCRIPTION
# [Issue-id 664](https://github.com/retaildevcrews/ngsa/issues/664)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add a new firewall application rule to section packages in "firewall_application_rule_collection_definition.tfvars" in order be able to pull down images from GitHub Packages (ghcr.io).

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->

- Follow terraform instruction to deploy from CAF aks-secure-baseline project 
- Follow instruction to deploy in-memory NGSA app
- Follow instruction to deploy loderunner 
- Verify that both Ngsa app and loderunner do not have any issues pulling their own images from git hub packages.

References: #664
