### PR TITLE
update flux values to match the settings in aks-secure-baseline

### DIFF
--- a/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/flux/README.md
+++ b/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/flux/README.md
@@ -1,10 +1,10 @@
 # Cluster Baseline Configuration for Continuous Deployment
-![License](https://img.shields.io/badge/license-MIT-green.svg)
 
+![License](https://img.shields.io/badge/license-MIT-green.svg)
 
 The following instructions will set up Flux in a Kubernetes cluster for continuous deployment of our application.
 
-### Prerequisites
+## Prerequisites
 
 - Kubernetes cluster
 - Helm v3
@@ -13,16 +13,20 @@ The following instructions will set up Flux in a Kubernetes cluster for continuo
 To install Fluxctl on Windows Subsystem for Linux:
 
 ```bash
+
 sudo wget https://github.com/fluxcd/flux/releases/download/1.17.1/fluxctl_windows_amd64 -O /usr/bin/fluxctl && sudo chmod +x /usr/bin/fluxctl
+
 ```
 
 To verify installed
 
 ```bash
+
 fluxctl version
+
 ```
 
-### Installation Instructions
+## Installation Instructions
 
 Add FluxCD repository to Helm repos
 
@@ -41,6 +45,7 @@ kubectl create ns cluster-baseline-settings
 ```
 
 Install Flux Helm chart. Make sure you are using the right values depending on the desired configuration.
+
 ```bash
 
 # change to this directory
@@ -65,17 +70,20 @@ helm upgrade -i flux fluxcd/flux --wait \
   --set git.url=$Git_Url \
   --set git.branch=$Git_Branch \
   --set git.path=$Git_Path \
-  --set additionalArgs={--sync-garbage-collection}
+  --set "additionalArgs={--sync-garbage-collection,--listen-metrics=:3031}"
 
 ```
 
 Install the `HelmRelease` Kubernetes custom resource definition
+
 ```bash
 
 kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/crds.yaml
 
 ```
+
 Install the Flux Helm Operator
+
 ``` bash
 
 helm upgrade -i helm-operator fluxcd/helm-operator --wait \
@@ -94,6 +102,7 @@ fluxctl identity --k8s-fwd-ns cluster-baseline-settings
 ```
 
 Your cluster should now sync with your configuration stored in GitHub. By default, the cluster looks for changes in the cluster every five minutes. To force a sync, use the following command.
+
 ``` bash
 
 fluxctl sync --k8s-fwd-ns cluster-baseline-settings

--- a/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/flux/flux-values.yaml
+++ b/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/flux/flux-values.yaml
@@ -10,7 +10,18 @@ nodeSelector:
 memcached:
   resources:
     requests:
-      cpu: 
+      cpu:
       memory: 512Mi
 
+image:
+  tag: 1.21.1
 
+git:
+  readonly: true
+  timeout: 5m
+
+sync:
+  state: secret
+
+registry:
+  disableScanning: true


### PR DESCRIPTION
## PR Checklist

---

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

The flux install instructions were not installing the cluster-baseline-settings files. This updates the settings for the helm deployment to match the settings from the upstream static yaml files. There is a task in the backlog to address why the original ngsa instructions are not working. https://github.com/retaildevcrews/ngsa/issues/700

aks-secure-baseline settings.
https://github.com/Azure/caf-terraform-landingzones-starter/blob/be4cab15f8734cbc0ed7b538a7a5b309110245e4/enterprise_scale/construction_sets/aks/online/aks_secure_baseline/cluster-baseline-settings/flux.yaml#L115-L119

```
        - --git-readonly
        - --sync-state=secret
        - --listen-metrics=:3031
        - --git-timeout=5m
        - --registry-disable-scanning=true
```

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

```bash
kubectl get pods -n cluster-baseline-settings
NAME                                     READY   STATUS    RESTARTS   AGE
aad-pod-identity-mic-cd9c49498-7vkjn     1/1     Running   0          21m
aad-pod-identity-mic-cd9c49498-g6wzr     1/1     Running   0          21m
aad-pod-identity-nmi-68897               1/1     Running   0          21m
aad-pod-identity-nmi-9l9ws               1/1     Running   0          21m
aad-pod-identity-nmi-vvxkv               1/1     Running   0          21m
csi-secrets-store-djrpc                  3/3     Running   0          21m
csi-secrets-store-drwng                  3/3     Running   0          21m
csi-secrets-store-mgb78                  3/3     Running   0          21m
csi-secrets-store-provider-azure-ckfwq   1/1     Running   0          21m
csi-secrets-store-provider-azure-rlgbz   1/1     Running   0          21m
csi-secrets-store-provider-azure-x79v6   1/1     Running   0          21m
flux-75687856c5-n62b9                    1/1     Running   0          22m
helm-operator-74b57db4c9-mpmqq           1/1     Running   0          18m
kured-bkwbn                              1/1     Running   0          21m
kured-dcz8h                              1/1     Running   0          21m
kured-dnsws                              1/1     Running   0          21m
kured-gjp6k                              1/1     Running   0          21m
kured-wp6xb                              1/1     Running   0          21m
kured-xg4v2                              1/1     Running   0          21m
```

Closes https://github.com/retaildevcrews/ngsa/issues/699
Refs: https://github.com/retaildevcrews/ngsa/issues/667